### PR TITLE
Bad Request 응답 본문 만들기

### DIFF
--- a/src/main/java/com/blueprint/whiteship_restapi/common/ErrorsSerializer.java
+++ b/src/main/java/com/blueprint/whiteship_restapi/common/ErrorsSerializer.java
@@ -1,0 +1,52 @@
+package com.blueprint.whiteship_restapi.common;
+
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.validation.Errors;
+
+import java.io.IOException;
+
+/**
+ * ErrorsSerializer를 objectmapper에 등록을 해야하는데 스프링에서 제공하는 JsonComponent 어노테이션을 사용하면 등록이 가능하다
+ * 이렇게 ErrorsSerializer를 구현하게 되면 objectMapper가 ErrorsSerializer를 사용한다.
+ * 언제 사용하냐면 Errors객체를 serialization할 때 사용한다.!!!!!!
+ * */
+@JsonComponent
+public class ErrorsSerializer extends JsonSerializer<Errors> {
+
+    @Override
+    public void serialize(Errors errors, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartArray();
+        errors.getFieldErrors().stream().forEach(e -> {
+            try {
+                gen.writeStartObject();
+                gen.writeStringField("field", e.getField());
+                gen.writeStringField("objectName", e.getObjectName());
+                gen.writeStringField("code", e.getCode());
+                gen.writeStringField("defaultMessage", e.getDefaultMessage());
+                Object rejectedValue = e.getRejectedValue();
+                if (rejectedValue != null) {
+                    gen.writeStringField("rejectedValue", rejectedValue.toString());
+                }
+                gen.writeEndObject();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        });
+        errors.getGlobalErrors().stream().forEach(e ->{
+            try {
+                gen.writeStartObject();
+                gen.writeStringField("objectName", e.getObjectName());
+                gen.writeStringField("code", e.getCode());
+                gen.writeStringField("defaultMessage", e.getDefaultMessage());
+                gen.writeEndObject();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
+        });
+        gen.writeEndArray();
+    }
+}

--- a/src/main/java/com/blueprint/whiteship_restapi/ebents/EventController.java
+++ b/src/main/java/com/blueprint/whiteship_restapi/ebents/EventController.java
@@ -37,19 +37,23 @@ public class EventController {
 
     @PostMapping
     public ResponseEntity createEvent(@RequestBody @Valid EventDto eventDto, Errors errors) {
-        if (errors.hasErrors()) {
-            return ResponseEntity.badRequest().build();
+//            응답에 에러값을 보내주고 싶을 경우
+//            return ResponseEntity.badRequest().build();
+//            이렇게 하면 될꺼 같지만 안된다. ! 이유: Errors는 자바빈 스팩을 준수하지 않기 때문이다.!
+//TODO ->> objectMapper에 여러 serializer가 등록이 되어있는데 객체를 json으로 변환할 때
+// objectMapper가 Beanserializer를 사용해서 json으로 변환을 한다.
+// Event 객체가 json으로 변환이 가능 했던건 자바빈 스팩을 준수 했기 때문이고
+// Errors 는 자바빈 스팩을 준수하지 않았기 때문에 변환을 시도하면 에러가 발생한다. 문제 해결방법.! ErrorsSerializer 생성
+        if (errors.hasErrors()){
+            return ResponseEntity.badRequest().body(errors);
         }
-
         eventValidator.validate(eventDto, errors);
         if (errors.hasErrors()) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(errors);
         }
         Event event = modelMapper.map(eventDto, Event.class);
         Event newEvent = this.eventRepository.save(event);
         URI createUri = linkTo(EventController.class).slash(newEvent.getId()).toUri();
         return ResponseEntity.created(createUri).body(event);
     }
-    
-
 }

--- a/src/main/java/com/blueprint/whiteship_restapi/ebents/EventValidator.java
+++ b/src/main/java/com/blueprint/whiteship_restapi/ebents/EventValidator.java
@@ -10,8 +10,7 @@ public class EventValidator {
 
     public void validate(EventDto eventDto, Errors errors) {
         if (eventDto.getBasePrice() > eventDto.getMaxPrice() && eventDto.getMaxPrice() != 0) {
-            errors.rejectValue("basePrice", "wrongValue","BasePrice is wrong.");
-            errors.rejectValue("maxPrice", "wrongValue","Maxprice is wrong.");
+            errors.reject("wrongPrices", "Values fo prices are wrong");
         }
 
         LocalDateTime endEventDateTime = eventDto.getEndEventDateTime();
@@ -21,7 +20,7 @@ public class EventValidator {
             errors.rejectValue("endEventDateTime","wrongValue","endEventDateTime is wrong.");
         }
 
-        //TODO beginEventDateTime
-        //TODO CloseEnrollmentDateTime
+        //TODO beginEventDateTime 이것도 구현해야됨
+        //TODO CloseEnrollmentDateTime 이것도 구현해야됨
     }
 }

--- a/src/test/java/com/blueprint/whiteship_restapi/ebents/EventControllerTests.java
+++ b/src/test/java/com/blueprint/whiteship_restapi/ebents/EventControllerTests.java
@@ -125,7 +125,7 @@ public class EventControllerTests {
 
     @Test
     @DisplayName("입력 값이 잘 못된 경우 발생하는 테스트")
-    void createEvent_Bad_req_Enpty_Input() throws Exception {
+    void createEvent_Bad_req_Wrong_Input() throws Exception {
         EventDto eventDto = EventDto.builder()
                 .name("Spring")
                 .description("REST API Development whth spring")
@@ -142,6 +142,12 @@ public class EventControllerTests {
         this.mockMvc.perform(post("/api/events")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(this.objectMapper.writeValueAsString(eventDto)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$[0].field").exists())
+                .andExpect(jsonPath("$[0].defaultMessage").exists())
+                .andExpect(jsonPath("$[0].objectName").exists())
+                .andExpect(jsonPath("$[0].defaultMessage").exists())
+                .andExpect(jsonPath("$[0].code").exists())
+        ;
     }
 }


### PR DESCRIPTION
ErrorsSerializer 생성 serialize 구현
응답 본문 테스트 중 테스가 깨졌는데 단순한 내 실수.!!
EventController createEvent 메서드에 ResponseEntity.badRequest().build()로 하고 테스트를 돌리고 있었다.
응답본문을 body에 담아서 넘겼어야 했는데. ㅠ.,ㅠ